### PR TITLE
Run Documentation Examples

### DIFF
--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -23,7 +23,10 @@ jobs:
 
       - name: Sphinx build
         run: |
-          sphinx-build doc _build
+          python deapi/simulated_server/initialize_server.py 13241 &
+          sleep 5 &&
+          sphinx-build doc _build &&
+          kill %1
 
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v3

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -18,6 +18,7 @@ extensions = ['sphinx.ext.autodoc',
               "sphinx.ext.autosummary",
                 "sphinx.ext.intersphinx",
                 "sphinx.ext.napoleon",
+              'sphinx_gallery.gen_gallery',
               ]
 templates_path = ['_templates']
 exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
@@ -45,5 +46,21 @@ autodoc_default_options = {
 }
 
 autosummary_generate = True
+
+# sphinx_gallery
+# --------------
+# https://sphinx-gallery.github.io/stable/configuration.html
+
+sphinx_gallery_conf = {
+    "examples_dirs": "../examples",
+    "gallery_dirs": "examples",
+    "filename_pattern": "^((?!sgskip).)*$",
+    "ignore_pattern":  "_sgskip.py",
+    "backreferences_dir": "api",
+    "doc_module": ("deapi",),
+    "reference_url": {
+        "deapi": None,
+    },
+}
 
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -5,6 +5,7 @@
   Introduction <intro.rst>
   Reference <reference/index>
   Get Help <help/help.rst>
+  Examples <examples/index.rst>
   Changes <changes.rst>
 
 

--- a/examples/setting_parameters/setting_up_stem.py
+++ b/examples/setting_parameters/setting_up_stem.py
@@ -11,13 +11,13 @@ This script will:
 5. Acquire a STEM image using a HAADF detector
 """
 
-from deapi.fake_client import FakeClient as Client
-# from deapi import Client
+from deapi import Client
 
 # %%
 # Connect to the DE server
 client = Client()
-client.connect()
+client.usingMmf = False
+client.connect(port=13241)  # connect to the running DE Server
 
 # %%
 # Set the hardware ROI to 256x256


### PR DESCRIPTION
This should run the documentation examples on a seperate thread. 

This allows the documentation to build (properly) using the sphinx-gallery.