### PR TITLE
Update Testing

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -67,13 +67,3 @@ jobs:
         uses: codecov/codecov-action@v4
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-
-
-  coveralls-finish:
-    needs: build-with-pip
-    runs-on: ubuntu-latest
-    steps:
-      - name: Coveralls finished
-        uses: AndreMiras/coveralls-python-action@develop
-        with:
-          parallel-finished: true

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,3 +12,6 @@ Unreleased
 - Renamed `Client` functions from CamelCase to snake_case (Legacy functions are still available)
 - Added buffer_protocol module for handling different buffer protocol files
 - Added a data_types module for handling different data types
+- Added a python based DEServer for testing purposes
+- Update the Testing to allow for a real DEServer to be used for testing (#7)
+- Add support for `@pytest.mark.server` decorator for tests that require a full DEServer to be running (#7)

--- a/deapi/client.py
+++ b/deapi/client.py
@@ -209,9 +209,6 @@ class Client:
         self.image_sizex = self["Image Size X (pixels)"]
         self.image_sizey = self["Image Size Y (pixels)"]
 
-    def plot_virtual_masks(self):
-        pass
-
     def disconnect(self):
         """
         Disconnects from the server.
@@ -1219,10 +1216,12 @@ class Client:
 
         return filePath
 
-    def print_server_info(self, camera):
+    def print_server_info(self, camera=None):
         """
         Print out the server information
         """
+        if camera is None:
+            camera = self["Camera Name"]
         print("Time        : " + datetime.now().strftime("%m/%d/%Y, %H:%M:%S"))
         print("Computer    : " + socket.gethostname())
         print("DE-Server   : " + self.GetProperty("Server Software Version"))

--- a/deapi/prop_dump.json
+++ b/deapi/prop_dump.json
@@ -413,5 +413,13 @@
     "category":"Basic",
     "options":"0.0, 1000000.0, '0.0 - 1000000.0'",
     "default_value":"1000"
+  },
+  "Camera Name":{
+    "value":"TestCamera",
+    "data_type":"String",
+    "value_type":"AllowAll",
+    "category":"Basic",
+    "options":"",
+    "default_value":"Camera"
   }
 }

--- a/deapi/simulated_server/fake_server.py
+++ b/deapi/simulated_server/fake_server.py
@@ -46,6 +46,7 @@ class Property:
         category,
         value_type,
         options,
+        default_value=None,
         set_expression=None,
         get_expression=None,
         set_also_expressions=None,
@@ -58,6 +59,7 @@ class Property:
         self.options = options
         self.server = server
         self._value = value
+        self.default_value = default_value
         self.set_expression = set_expression
         self.get_expression = get_expression
         self.set_also_expressions = set_also_expressions
@@ -161,6 +163,7 @@ class FakeServer:
                     category=values[v]["category"],
                     value_type=values[v]["value_type"],
                     options=values[v]["options"],
+                    default_value=values[v]["default_value"],
                     server=self,
                     set_expression=values[v].get("set", None),
                     get_expression=values[v].get("get", None),
@@ -381,27 +384,29 @@ class FakeServer:
             name.replace(" ", "_").lower().replace("(", "").replace(")", "")
         ]
 
-        str_mapping = {
-            "value": "Value",
-            "category": "Category",
-            "data_type": "Data Type",
-            "value_type": "Value Type",
-        }
+        list_props = [
+            "data_type",
+            "value_type",
+            "category",
+            "options",
+            "default_value",
+            "value",
+        ]
 
-        for key, value in str_mapping.items():
+        for key in list_props:
             param = ack1.parameter.add()
-            if isinstance(prop_dict[key], bool):
+            if isinstance(getattr(prop_dict, key), bool):
                 param.type = pb.AnyParameter.P_BOOL
-                param.p_bool = prop_dict[key]
-            elif isinstance(prop_dict[key], int):
+                param.p_bool = getattr(prop_dict, key)
+            elif isinstance(getattr(prop_dict, key), int):
                 param.type = pb.AnyParameter.P_INT
-                param.p_int = prop_dict[key]
-            elif isinstance(prop_dict[key], float):
+                param.p_int = getattr(prop_dict, key)
+            elif isinstance(getattr(prop_dict, key), float):
                 param.type = pb.AnyParameter.P_FLOAT
-                param.p_float = prop_dict[key]
+                param.p_float = getattr(prop_dict, key)
             else:
                 param.type = pb.AnyParameter.P_STRING
-                param.p_string = prop_dict[key]
+                param.p_string = getattr(prop_dict, key)
 
         return (acknowledge_return,)
 

--- a/deapi/simulated_server/initialize_server.py
+++ b/deapi/simulated_server/initialize_server.py
@@ -10,7 +10,7 @@ import time
 
 
 # Defining main function
-def main(port=13241):
+def main(port=13240):
 
     HOST = "127.0.0.1"  # Standard loopback interface address (localhost)
     PORT = port  # Port to listen on (non-privileged ports are > 1023)

--- a/deapi/tests/conftest.py
+++ b/deapi/tests/conftest.py
@@ -9,6 +9,7 @@ import numpy as np
 from deapi.client import Client
 
 
+# Modifying pytest run options
 def pytest_addoption(parser):
     parser.addoption(
         "--server",
@@ -20,6 +21,23 @@ def pytest_addoption(parser):
         "--host", action="store", default="127.0.0.1", help="host to connect to"
     )
     parser.addoption("--port", action="store", default=13240, help="port to connect to")
+
+
+def pytest_configure(config):
+    config.addinivalue_line(
+        "markers", "server: mark tests that require the full DEServer"
+    )
+
+
+def pytest_collection_modifyitems(config, items):
+    if config.getoption("--server"):
+        # Do not skip server tests
+        return
+    else:  # pragma: no cover
+        skip_server = pytest.mark.skip(reason="need --server option to run")
+        for item in items:
+            if "server" in item.keywords:
+                item.add_marker(skip_server)
 
 
 @pytest.fixture(scope="module")

--- a/deapi/tests/conftest.py
+++ b/deapi/tests/conftest.py
@@ -1,24 +1,56 @@
-import sys, socket, pytest, py, pathlib
+import sys
+import pytest
+import pathlib
 from xprocess import ProcessStarter
+import sys
+
+import numpy as np
+
 from deapi.client import Client
 
-import time
-import numpy as np
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--server",
+        action="store_true",
+        default=False,
+        help="If a remote server is running",
+    )
+    parser.addoption(
+        "--host", action="store", default="127.0.0.1", help="host to connect to"
+    )
+    parser.addoption("--port", action="store", default=13240, help="port to connect to")
 
 
 @pytest.fixture(scope="module")
-def client(xprocess):
-    port = np.random.randint(5000, 9999)
-    curdir = pathlib.Path(__file__).parent.parent
+def client(xprocess, request):
+    if request.config.getoption("--server"):
+        c = Client()
+        if request.config.getoption("--host") != "127.0.0.1" or sys.platform != "win32":
+            c.usingMmf = False
+        c.connect(
+            host=request.config.getoption("--host"),
+            port=request.config.getoption("--port"),
+        )
+        yield c
+        c.disconnect()
+        return
+    else:
+        port = np.random.randint(5000, 9999)
+        curdir = pathlib.Path(__file__).parent.parent
 
-    class Starter(ProcessStarter):
-        timeout = 20
-        pattern = "started"
-        args = [sys.executable, curdir / "simulated_server/initialize_server.py", port]
+        class Starter(ProcessStarter):
+            timeout = 20
+            pattern = "started"
+            args = [
+                sys.executable,
+                curdir / "simulated_server/initialize_server.py",
+                port,
+            ]
 
-    xprocess.ensure("server-%s" % port, Starter)
-    c = Client()
-    c.usingMmf = False
-    c.connect(port=port)
-    yield c
-    xprocess.getinfo("server-%s" % port).terminate()
+        xprocess.ensure("server-%s" % port, Starter)
+        c = Client()
+        c.usingMmf = False
+        c.connect(port=port)
+        yield c
+        xprocess.getinfo("server-%s" % port).terminate()

--- a/deapi/tests/test_client.py
+++ b/deapi/tests/test_client.py
@@ -133,3 +133,10 @@ class TestClient:
         result = client.get_result("virtual_image3")
         assert result is not None
         assert result[0].shape == (10, 10)
+
+    def test_property_spec_set(self, client):
+        client.set_property("Binning Y", 2)
+        sp = client.get_property_spec("Binning Y")
+        assert isinstance(sp, PropertySpec)
+        assert sp.currentValue == "2"
+        assert sp.options == ["1", "2", "4", "8"]

--- a/deapi/tests/test_client.py
+++ b/deapi/tests/test_client.py
@@ -134,6 +134,7 @@ class TestClient:
         assert result is not None
         assert result[0].shape == (10, 10)
 
+    @pytest.mark.server
     def test_property_spec_set(self, client):
         client.set_property("Binning Y", 2)
         sp = client.get_property_spec("Binning Y")

--- a/doc/help/dev_guide.rst
+++ b/doc/help/dev_guide.rst
@@ -86,3 +86,5 @@ default port and host. You can also specify the host and port using the followin
 
     pytest tests/ --server --host <host> --port <port>
 
+This will also run a subset of the tests that require a full DEServer to be running. These tests are marked with the
+`@pytest.mark.server` decorator.

--- a/doc/help/dev_guide.rst
+++ b/doc/help/dev_guide.rst
@@ -77,7 +77,12 @@ If you have a real DEServer running on a different machine, you can run the test
 
 .. code-block::
 
-    pytest tests/ --server <address> --port <port>
+    pytest tests/ --server
 
-This will run the tests using the DEServer at the specified address and port for the tests.
+This will run the tests using the DEServer at the specified address and port for the tests using the
+default port and host. You can also specify the host and port using the following command:
+
+.. code-block::
+
+    pytest tests/ --server --host <host> --port <port>
 


### PR DESCRIPTION
This is a small PR for updating the Testing and allowing us to run tests both using the python based server and the full DEServer program.

Status:
- [x] Changelog
- [x] Add support for @pytest.mark.server decorator
- [x] Add support for running on a different server and not spawning one via conftest
- [x] Fix Documentation