### PR TITLE
Commandline Server

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,3 +15,4 @@ Unreleased
 - Added a python based DEServer for testing purposes
 - Update the Testing to allow for a real DEServer to be used for testing (#7)
 - Add support for `@pytest.mark.server` decorator for tests that require a full DEServer to be running (#7)
+- Add a commandline interface for the pydeserver. (#8) Running `pydeserver --port 13241` will start the server on port 13241

--- a/deapi/simulated_server/initialize_server.py
+++ b/deapi/simulated_server/initialize_server.py
@@ -21,7 +21,7 @@ def main(port=13240):
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as server_socket:
         server_socket.bind((HOST, PORT))
         server_socket.listen()
-        sys.stderr.write("Server started.... \n\n")
+        sys.stderr.write("started .... \n\n")
         sys.stderr.flush()
         sys.stderr.write(
             "Waiting for a Connection to: \n"

--- a/deapi/simulated_server/initialize_server.py
+++ b/deapi/simulated_server/initialize_server.py
@@ -1,23 +1,33 @@
 import sys
 
-from fake_server import FakeServer
+from deapi.simulated_server.fake_server import FakeServer
 import socket
 import struct
 from deapi.buffer_protocols import pb
-import logging
 import sys
-import time
+import argparse
 
 
 # Defining main function
 def main(port=13240):
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--port", type=int, help="Port to listen on")
+    args = parser.parse_args()
+    if args.port:
+        port = args.port
 
     HOST = "127.0.0.1"  # Standard loopback interface address (localhost)
     PORT = port  # Port to listen on (non-privileged ports are > 1023)
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as server_socket:
         server_socket.bind((HOST, PORT))
         server_socket.listen()
-        sys.stderr.write("started")
+        sys.stderr.write("Server started.... \n\n")
+        sys.stderr.flush()
+        sys.stderr.write(
+            "Waiting for a Connection to: \n"
+            f"    Host: {HOST}\n"
+            f"    Port: {PORT} \n"
+        )
         sys.stderr.flush()
         while True:
             conn, addr = server_socket.accept()  # What waits for a connection

--- a/deapi/simulated_server/initialize_server.py
+++ b/deapi/simulated_server/initialize_server.py
@@ -9,12 +9,15 @@ import argparse
 
 
 # Defining main function
-def main(port=13240):
+def main(port=13241):
     parser = argparse.ArgumentParser()
     parser.add_argument("--port", type=int, help="Port to listen on")
-    args = parser.parse_args()
-    if args.port:
-        port = args.port
+    try:
+        args = parser.parse_args()
+        if args.port:
+            port = args.port
+    except:
+        pass
 
     HOST = "127.0.0.1"  # Standard loopback interface address (localhost)
     PORT = port  # Port to listen on (non-privileged ports are > 1023)

--- a/doc/help/pyDEServer.rst
+++ b/doc/help/pyDEServer.rst
@@ -10,7 +10,7 @@ The pyDEServer can be started by running the following command:
 
 .. code-block::
 
-    pyDEServer --port 13241
+    pydeserver --port 13241
 
 Motivation
 ----------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,3 +69,6 @@ Conda-forge = "https://anaconda.org/conda-forge/hyperspy"
 Homepage = "https://hyperspy.org"
 Support = "https://gitter.im/hyperspy/hyperspy"
 Source = "https://github.com/hyperspy/hyperspy"
+
+[project.scripts]
+pydeserver = "deapi.simulated_server.initialize_server:main"


### PR DESCRIPTION
Add Support for a command line server:


Running the following in a new command line session:

```
$ pydeserver --port 23433
```

Will start up a python based server and you can use that for testing