### PR TITLE
New Feature: Add Preview Website for PRs

### DIFF
--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -9,7 +9,6 @@ on:
 
 permissions:
   contents: write   # needed for gh-pages deployment
-  issues: write     # needed for PR comments
 
 jobs:
   docs:
@@ -56,12 +55,13 @@ jobs:
           comment: false   # disable built-in sticky comment
 
       - name: Comment
+        if: github.event_name == 'pull_request'
         uses: marocchino/sticky-pull-request-comment@v2
         with:
           header: pr-preview
           message: |
             **Preview for PR #${{ github.event.number }}**
             [View the preview here](https://previewde.github.io/deapi-preview/pr-preview/pr-${{ github.event.number }}/)
-            *(Built from a fork branch and deployed to `[PreviewDE/deapi-preview`](https://github.com/previewde/deapi-preview)*
+            *(Built from a fork branch and deployed to [PreviewDE/deapi-preview](https://github.com/PreviewDE/deapi-preview))*
         env:
           GITHUB_TOKEN: ${{ secrets.PR_COMMENT_TOKEN }}

--- a/deapi/conf.py
+++ b/deapi/conf.py
@@ -89,6 +89,9 @@ html_theme_options = {
     "use_edit_page_button": True,
     "navbar_start": ["navbar-logo"],
 }
+import os
+
+# -- General HTML configuration ---------------------------------------------
 
 html_context = {
     "github_user": "deapi",
@@ -97,98 +100,68 @@ html_context = {
     "doc_path": "doc",
 }
 
-# Add any paths that contain custom static files (such as style sheets) here,
-# relative to this directory. They are copied after the builtin static files, so
-# a file named "default.css" will overwrite the builtin "default.css".
-# html_static_path = ["_static"]
-
-# Syntax highlighting
-pygments_style = "friendly"
-
-napoleon_google_docstring = False
-napoleon_use_param = False
-napoleon_use_ivar = True
-nitpicky = True
-
-# Figure references
-numfig = True
-
-# nbsphinx configuration
-# Taken from nbsphinx' own nbsphinx configuration file, with slight
-# modification to point nbviewer and Binder to the GitHub master links
-# when the documentation is launched from a deapi version with
-# "dev" in the version.
-if "dev" in version:
-    release_version = "master"
-else:
-    release_version = "v" + version
-# https://nbsphinx.readthedocs.io/en/0.8.0/never-execute.html
-nbsphinx_execute = "never"  # auto, always, never
-nbsphinx_kernel_name = "python3"
-nbsphinx_allow_errors = True
-exclude_patterns = ["_build", "**.ipynb_checkpoints", "examples/*/*.ipynb"]
-
-# sphinxcontrib-bibtex configuration
-bibtex_bibfiles = ["bibliography.bib"]
-
-
-# -- Sphinx-Gallery---------------
-# https://sphinx-gallery.github.io
-sphinx_gallery_conf = {
-    "backreferences_dir": "reference/generated",
-    "doc_module": ("deapi",),
-    "examples_dirs": "../examples",  # path to your example scripts
-    "gallery_dirs": "examples",  # path to where to save gallery generated output
-    "filename_pattern": "^((?!sgskip).)*$",  # pattern to define which will be executed
-    "ignore_pattern": "_sgskip.py",  # pattern to define which will not be executed
-    "reference_url": {"deapi": None},
-    "show_memory": True,
-}
-
-autodoc_default_options = {
-    "show-inheritance": True,
-}
-
-graphviz_output_format = "svg"
-
-
-# Use relative URLs for static files
+# Use relative URLs for all pages and assets
 html_use_relative_urls = True
 
-# -- Options for HTML output -----------------------------------------------
-
+# -- HTML static files (CSS/JS) --------------------------------------------
 html_static_path = ["_static"]
 
-# Dynamically set the base URL for PR previews
-pr_number = os.environ.get("GITHUB_PR_NUMBER")  # set in workflow
+# Add extra CSS files if needed
+html_css_files = [
+    "custom.css",  # your custom CSS
+]
+
+# -- Dynamic base URL for main vs PR preview --------------------------------
+pr_number = os.environ.get("GITHUB_PR_NUMBER")
 if pr_number:
+    # PR preview URL path
     html_baseurl = (
         f"https://previewde.github.io/deapi-preview/pr-preview/pr-{pr_number}/"
     )
 else:
-    html_baseurl = "https://directelectron.github.io/deapi/"  # main branch
+    # Main branch URL
+    html_baseurl = "https://directelectron.github.io/deapi/"
 
-
-# sphinx.ext.autodoc
-# ------------------
-# https://www.sphinx-doc.org/en/master/usage/extensions/autodoc.html
-autosummary_ignore_module_all = False
-autosummary_imported_members = True
-autodoc_typehints_format = "short"
-autodoc_default_options = {
-    "show-inheritance": True,
+# -- Theme and theme options -------------------------------------------------
+html_theme = "sphinx_rtd_theme"
+html_theme_options = {
+    "collapse_navigation": False,
+    "sticky_navigation": False,
 }
 
+# -- Sphinx-Gallery configuration -------------------------------------------
+sphinx_gallery_conf = {
+    "backreferences_dir": "reference/generated",
+    "doc_module": ("deapi",),
+    "examples_dirs": "../examples",
+    "gallery_dirs": "examples",
+    "filename_pattern": "^((?!sgskip).)*$",
+    "ignore_pattern": "_sgskip.py",
+    "reference_url": {"deapi": None},
+    "show_memory": True,
+}
+
+# -- Autodoc and other extensions -------------------------------------------
+autodoc_default_options = {"show-inheritance": True}
 autosummary_generate = True
+graphviz_output_format = "svg"
+pygments_style = "friendly"
+napoleon_google_docstring = False
+napoleon_use_param = False
+napoleon_use_ivar = True
+nitpicky = True
+numfig = True
+nbsphinx_execute = "never"
+nbsphinx_kernel_name = "python3"
+nbsphinx_allow_errors = True
+exclude_patterns = ["_build", "**.ipynb_checkpoints", "examples/*/*.ipynb"]
+bibtex_bibfiles = ["bibliography.bib"]
 
 
-# This is the expected signature of the handler for this event, cf doc
+# -- Autodoc skip handler ---------------------------------------------------
 def autodoc_skip_member(app, what, name, obj, skip, options):
-    # Basic approach; you might want a regex instead
     return False
 
 
-# Automatically called by sphinx at startup
 def setup(app):
-    # Connect the autodoc-skip-member event from apidoc to the callback
     app.connect("autodoc-skip-member", autodoc_skip_member)


### PR DESCRIPTION
This adds in a Preview website when submitting a PR.  This preview website is hosted on a __seperate__ repo (and account) to minimize the security risks and to seperate the preview GitHub pages from the final documentation. 
